### PR TITLE
Save output as binary

### DIFF
--- a/lib/simplecov-rcov.rb
+++ b/lib/simplecov-rcov.rb
@@ -48,7 +48,7 @@ class SimpleCov::Formatter::RcovFormatter
   def write_file(template, output_filename, binding)
     rcov_result = template.result( binding )
 
-    File.open( output_filename, "w" ) do |file_result|
+    File.open( output_filename, "wb" ) do |file_result|
      file_result.write rcov_result
     end
   end


### PR DESCRIPTION
This is a PR from the main repository that I have pulled over to our fork.

See: https://github.com/fguillen/simplecov-rcov/pull/22

------------------

because simplecov originally reads the source file as binary
https://github.com/colszowka/simplecov/blob/v0.16.1/lib/simplecov/source_file.rb#L94.

This Encoding::UndefinedConversionError
https://github.com/fguillen/simplecov-rcov/issues/20
is essentially caused by the mismatch of protocols between read and
writes.

If we always use the template encoding of views/detail.html.erb (UTF-8),
it should work for many cases, but such a fix won't work for an encoding
which is not compatible with UTF-8. So this patch should be the best
fix for this issue.